### PR TITLE
Emscripten spike

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # using emscripten.
 # ----------------------------------------------------------------------
 
-EMSCRIPTEN_DOCKER_RUN=docker run --rm -v $(CURDIR)/deps/build:/src -v $(CURDIR)/src/lib:/src/lib -u emscripten trzeci/emscripten:sdk-tag-1.38.8-64bit
+EMSCRIPTEN_DOCKER_RUN=docker run --rm -v $(CURDIR)/deps/build:/src -v $(CURDIR)/src/lib:/src/lib -u emscripten trzeci/emscripten:sdk-tag-1.39.4-64bit
 CC=$(EMSCRIPTEN_DOCKER_RUN) emcc
 
 export

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,9 @@ deps:
 dist/libpcre2.js: src/lib/libpcre2.c src/lib/config.js | deps dist
 	$(CC) /src/lib/libpcre2.c \
 		-s WASM=1 \
+		-O3 \
 		--pre-js /src/lib/config.js \
+		-s EXPORTED_FUNCTIONS='["_malloc", "_free"]' \
 		-s EXTRA_EXPORTED_RUNTIME_METHODS='["cwrap", "ccall", "getValue"]' \
 		-I/src/local/include \
 		-L/src/local/lib \

--- a/test/PCRETest.js
+++ b/test/PCRETest.js
@@ -38,7 +38,7 @@ describe(`PCRE`, function () {
   describe(`instance property`, function () {
     describe(`match()`, function () {
       let re
-      const subject = 'fe fi fo fum';
+      const subject = 'fe fi fo fum'
 
       beforeEach(function () {
         re = new PCRE('(?<first_f>f)(?<the_rest>[a-z]+)')
@@ -54,21 +54,21 @@ describe(`PCRE`, function () {
       })
 
       it(`should return array with matching string on match`, function () {
-        const matches = re.match(subject);
+        const matches = re.match(subject)
 
-        assert.strictEqual(matches[0].match, 'fe');
+        assert.strictEqual(matches[0].match, 'fe')
       })
 
       it(`should return named groups`, () => {
-        const matches = re.match(subject);
+        const matches = re.match(subject)
 
-        assert('first_f' in matches);
-        assert('the_rest' in matches);
+        assert('first_f' in matches)
+        assert('the_rest' in matches)
       })
 
       it(`should return numbered groups`, () => {
-        const matches = re.match(subject);
-        assert.strictEqual(matches.length, 3);
+        const matches = re.match(subject)
+        assert.strictEqual(matches.length, 3)
       })
     })
   })


### PR DESCRIPTION
Trying to work around the v8 wasm compiler bug that causes v8 to take an 80-second freakout of CPU and memory when compiling pcre2_match()